### PR TITLE
Send user local time with chat prompts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,12 @@ type ChatMessage = {
   citations?: string[];
 };
 
+type ApiChatMessage = {
+  role: "system" | "user" | "assistant";
+  content: string;
+  citations?: string[];
+};
+
 type GameItem = {
   teamName: string;
   opponent: string;
@@ -87,10 +93,16 @@ export default function Home() {
     setMessages([...nextMessages, { role: "assistant", content: "" }]);
     setIsLoading(true);
     try {
+      const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      const timeMessage: ApiChatMessage = {
+        role: "system",
+        content: `User local time: ${new Date().toLocaleString()} (${timezone})`,
+      };
+      const apiMessages: ApiChatMessage[] = [timeMessage, ...nextMessages];
       const res = await fetch("/api/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ messages: nextMessages }),
+        body: JSON.stringify({ messages: apiMessages }),
       });
       if (!res.body) {
         throw new Error("No response body");


### PR DESCRIPTION
## Summary
- include `ApiChatMessage` type for system messages in the client
- prepend system message containing user's local time and timezone to every chat request

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9184bfccc8329beced7dae496e83c