### PR TITLE
Fix Perplexity API 404 by using strict OpenAI compatibility

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -104,6 +104,10 @@ export async function POST(request: Request) {
     const perplexity = createOpenAI({
       apiKey,
       baseURL: "https://api.perplexity.ai",
+      // Perplexity uses the OpenAI Chat Completions endpoint, not the
+      // new Responses API. Enforce strict compatibility so requests hit
+      // `/chat/completions` instead of `/responses` which returns 404.
+      compatibility: "strict",
     });
 
     const result = await streamText({

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -104,14 +104,12 @@ export async function POST(request: Request) {
     const perplexity = createOpenAI({
       apiKey,
       baseURL: "https://api.perplexity.ai",
-      // Perplexity uses the OpenAI Chat Completions endpoint, not the
-      // new Responses API. Enforce strict compatibility so requests hit
-      // `/chat/completions` instead of `/responses` which returns 404.
-      compatibility: "strict",
+      // Perplexity only supports the OpenAI Chat Completions API. Using the
+      // chat model avoids hitting the unsupported `/responses` endpoint.
     });
 
     const result = await streamText({
-      model: perplexity(modelName),
+      model: perplexity.chat(modelName),
       messages: [
         { role: "system", content: SYSTEM_PROMPT },
         systemPreamble,


### PR DESCRIPTION
## Summary
- fix Perplexity calls 404ing by forcing OpenAI compatibility to use chat/completions instead of responses

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a920d004288329b70978a005c39ccd